### PR TITLE
Fix SSL certificate handling in database connection

### DIFF
--- a/scripts/upload.ts
+++ b/scripts/upload.ts
@@ -128,7 +128,10 @@ export async function uploadDocuments(
 
   // Connect to database
   const pool = new Pool({
-    connectionString: process.env.SERENDB_CONNECTION_STRING
+    connectionString: process.env.SERENDB_CONNECTION_STRING,
+    ssl: {
+      rejectUnauthorized: false
+    }
   })
 
   let uploaded = 0


### PR DESCRIPTION
## Problem
Upload script was failing with `DEPTH_ZERO_SELF_SIGNED_CERT` error when connecting to SerenDB:
```
Error: self-signed certificate; if the root CA is installed locally, try running Node.js with --use-system-ca
```

## Solution
Added SSL configuration to PostgreSQL connection pool to accept self-signed certificates:
```typescript
const pool = new Pool({
  connectionString: process.env.SERENDB_CONNECTION_STRING,
  ssl: {
    rejectUnauthorized: false
  }
})
```

## Impact
- Allows upload script to connect to SerenDB with SSL-enabled connections
- Unblocks upload of 52,401 extracted text files
- Required for development/testing environments with self-signed certificates

## Testing
- Local testing needed: `pnpm upload` should now connect successfully