### PR TITLE
Fix SSL connection string parameter conflicts

### DIFF
--- a/scripts/upload.ts
+++ b/scripts/upload.ts
@@ -127,8 +127,13 @@ export async function uploadDocuments(
   }
 
   // Connect to database
+  // Remove SSL mode from connection string if present, we'll handle it explicitly
+  const connectionString = process.env.SERENDB_CONNECTION_STRING!
+    .replace(/[?&]sslmode=[^&]*/g, '')
+    .replace(/[?&]channel_binding=[^&]*/g, '')
+
   const pool = new Pool({
-    connectionString: process.env.SERENDB_CONNECTION_STRING,
+    connectionString,
     ssl: {
       rejectUnauthorized: false
     }


### PR DESCRIPTION
## Problem
Even after PR #54 added SSL config with `rejectUnauthorized: false`, the upload still fails because the connection string contains:
```
?sslmode=require&channel_binding=require
```

These parameters in the connection string conflict with the explicit SSL configuration in the Pool config, causing the self-signed certificate error to persist.

## Solution
Strip `sslmode` and `channel_binding` parameters from the connection string before passing it to the Pool constructor:

```typescript
const connectionString = process.env.SERENDB_CONNECTION_STRING!
  .replace(/[?&]sslmode=[^&]*/g, '')
  .replace(/[?&]channel_binding=[^&]*/g, '')

const pool = new Pool({
  connectionString,
  ssl: {
    rejectUnauthorized: false
  }
})
```

## Impact
- Removes conflicting SSL parameters from connection string
- Allows explicit SSL config to take precedence
- Enables upload of 52,401 extracted files to SerenDB
- Resolves the DEPTH_ZERO_SELF_SIGNED_CERT error

## Testing
Ready to test with `pnpm upload`