### PR TITLE
feat: add provider update script and enforce email requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,20 @@
     "extract": "tsx scripts/extract.ts",
     "upload": "tsx scripts/upload.ts",
     "backup": "tsx scripts/backup.ts",
-    "register": "tsx scripts/register-provider.ts"
+    "register": "tsx scripts/register-provider.ts",
+    "update-provider": "tsx scripts/update-provider.ts"
   },
   "devDependencies": {
     "tsx": "^4.7.0",
     "typescript": "^5.3.3"
   },
-  "keywords": ["micropayments", "x402", "serendb", "mcp", "ai-agents"],
+  "keywords": [
+    "micropayments",
+    "x402",
+    "serendb",
+    "mcp",
+    "ai-agents"
+  ],
   "author": "",
   "license": "MIT"
 }

--- a/scripts/register-provider.ts
+++ b/scripts/register-provider.ts
@@ -108,7 +108,13 @@ export async function configurePricing(): Promise<void> {
 
 // CLI entry point
 if (import.meta.url === `file://${process.argv[1]}`) {
-  const email = process.argv[2] || 'admin@example.com'
+  const email = process.argv[2]
+
+  if (!email) {
+    console.error('Error: Please provide an email address.')
+    console.error('Usage: pnpm register <email>')
+    process.exit(1)
+  }
 
   // If provider credentials already exist, skip registration
   const hasProviderCredentials = process.env.X402_PROVIDER_ID && process.env.X402_API_KEY

--- a/scripts/update-provider.ts
+++ b/scripts/update-provider.ts
@@ -1,0 +1,106 @@
+// ABOUTME: Updates provider information on x402 gateway
+// ABOUTME: Allows updating provider name, email, wallet address, and connection string
+
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+export interface ProviderUpdate {
+    name?: string
+    email?: string
+    walletAddress?: string
+    connectionString?: string
+}
+
+export function validateEnvironment(requiredVars: string[]): void {
+    const missing = requiredVars.filter(varName => !process.env[varName])
+
+    if (missing.length > 0) {
+        throw new Error(`Missing required environment variables: ${missing.join(', ')}`)
+    }
+}
+
+export async function updateProvider(updates: ProviderUpdate): Promise<void> {
+    validateEnvironment(['X402_GATEWAY_URL', 'X402_API_KEY'])
+
+    const gatewayUrl = process.env.X402_GATEWAY_URL!
+    const apiKey = process.env.X402_API_KEY!
+
+    // Use the new update endpoint on serenai-x402.vercel.app
+    const updateUrl = gatewayUrl.replace('x402.serendb.com', 'serenai-x402.vercel.app')
+
+    console.log('Updating provider information...')
+
+    const response = await fetch(`${updateUrl}/api/providers/update`, {
+        method: 'PATCH',
+        headers: {
+            'Authorization': `Bearer ${apiKey}`,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(updates)
+    })
+
+    if (!response.ok) {
+        const error = await response.text()
+        throw new Error(`Update failed: ${error}`)
+    }
+
+    const result = await response.json()
+
+    console.log('\n✓ Provider updated successfully!')
+    console.log('Updated fields:', Object.keys(updates).join(', '))
+
+    return result
+}
+
+// CLI entry point
+if (import.meta.url === `file://${process.argv[1]}`) {
+    const args = process.argv.slice(2)
+
+    if (args.length === 0) {
+        console.error('Error: Please provide at least one field to update.')
+        console.error('Usage: pnpm update-provider [--name <name>] [--email <email>] [--wallet <address>] [--connection <string>]')
+        console.error('\nExamples:')
+        console.error('  pnpm update-provider --name "New Provider Name"')
+        console.error('  pnpm update-provider --email admin@newdomain.com --name "Updated Name"')
+        process.exit(1)
+    }
+
+    const updates: ProviderUpdate = {}
+
+    for (let i = 0; i < args.length; i += 2) {
+        const flag = args[i]
+        const value = args[i + 1]
+
+        if (!value) {
+            console.error(`Error: Missing value for ${flag}`)
+            process.exit(1)
+        }
+
+        switch (flag) {
+            case '--name':
+                updates.name = value
+                break
+            case '--email':
+                updates.email = value
+                break
+            case '--wallet':
+                updates.walletAddress = value
+                break
+            case '--connection':
+                updates.connectionString = value
+                break
+            default:
+                console.error(`Error: Unknown flag ${flag}`)
+                console.error('Valid flags: --name, --email, --wallet, --connection')
+                process.exit(1)
+        }
+    }
+
+    updateProvider(updates)
+        .then(() => process.exit(0))
+        .catch(err => {
+            console.error('Update failed:', err)
+            process.exit(1)
+        })
+}


### PR DESCRIPTION
- Add scripts/update-provider.ts to update provider info via PATCH endpoint
- Add update-provider script to package.json
- Enforce email requirement in register-provider.ts (remove default email)
- Exit with error if no email provided to pnpm register